### PR TITLE
Fix issue #10

### DIFF
--- a/bi_lstm_crf/app/predict.py
+++ b/bi_lstm_crf/app/predict.py
@@ -52,7 +52,9 @@ class WordsTagger:
             return []
 
         def _tokens(sentence, ts):
-            begins = [(idx, t[2:]) for idx, t in enumerate(ts) if t[0] in begin_tags + "O"] + [(len(ts), "O")]
+            begins = [(idx, t[2:]) for idx, t in enumerate(ts) if t[0] in begin_tags + "O"]
+            if (len(begins) < len(ts)):
+                begins.append((len(ts), "O"))
             begins = [b for idx, b in enumerate(begins) if idx == 0 or ts[idx] != "O" or ts[idx - 1] != "O"]
             if begins[0][0] != 0:
                 print('warning: tags does begin with any of {}: \n{}\n{}'.format(begin_tags, sentence, ts))


### PR DESCRIPTION
I figured out the problem. When the sentence has all token as "O" the `_tokens` method creates begins with one extra position causing the index out of range in `ts[idx]`. To fix that I checked the size of the array before comparing. If the size of begins is less than ts size, then there is at least one token that isn't "O". So the method can add the "O" token in the last index of the array.