### PR TITLE
Add dropout module

### DIFF
--- a/bi_lstm_crf/app/train.py
+++ b/bi_lstm_crf/app/train.py
@@ -99,6 +99,7 @@ def main():
     parser.add_argument('--num_epoch', type=int, default=20, help="number of epoch to train")
     parser.add_argument('--lr', type=float, default=1e-3, help='learning rate')
     parser.add_argument('--weight_decay', type=float, default=0., help='the L2 normalization parameter')
+    parser.add_argument('--dropout', type=float, default=0., help='dropout rate for embedding, LSTM, and CRF')
     parser.add_argument('--batch_size', type=int, default=1000, help='batch size for training')
     parser.add_argument('--device', type=str, default=None,
                         help='the training device: "cuda:0", "cpu:0". It will be auto-detected by default')

--- a/bi_lstm_crf/app/utils.py
+++ b/bi_lstm_crf/app/utils.py
@@ -16,7 +16,7 @@ def model_filepath(model_dir):
 
 def build_model(args, processor, load=True, verbose=False):
     model = BiRnnCrf(len(processor.vocab), len(processor.tags),
-                     embedding_dim=args.embedding_dim, hidden_dim=args.hidden_dim, num_rnn_layers=args.num_rnn_layers)
+                     embedding_dim=args.embedding_dim, hidden_dim=args.hidden_dim, dropout=args.dropout, num_rnn_layers=args.num_rnn_layers)
 
     # weights
     model_path = model_filepath(args.model_dir)


### PR DESCRIPTION
For the training of NN, it is known that dropout improves the performance.
I added the dropout module to the embedding, the LSTM output, and LSTM layers.
Also, I revised argparse to take the dropout rate, so now you can specify the dropout rate as follows:

```
$ python -m bi_lstm_crf corpus_dir --model_dir model --dropout 0.3
```

All dropout modules share the same dropout rate in this commit.
On the local NER dataset, this dropout contributes to +5% F1 improvement :)